### PR TITLE
add support for basicAuth to pass apiKey.

### DIFF
--- a/snap/plugin/snap-collector-ns1/ns1/ns1.go
+++ b/snap/plugin/snap-collector-ns1/ns1/ns1.go
@@ -119,7 +119,7 @@ func (n *Ns1) ZoneMetrics(client *Client, mts []plugin.MetricType) ([]plugin.Met
 		}
 		metrics = append(metrics, plugin.MetricType{
 			Data_:      qps.Qps,
-			Namespace_: core.NewNamespace([]string{"raintank", "apps", "ns1", "zones", zSlug, "qps"}),
+			Namespace_: core.NewNamespace("raintank", "apps", "ns1", "zones", zSlug, "qps"),
 			Timestamp_: time.Now(),
 			Version_:   mts[0].Version(),
 		})
@@ -177,7 +177,7 @@ func (n *Ns1) MonitorsMetrics(client *Client, mts []plugin.MetricType) ([]plugin
 
 			metrics = append(metrics, plugin.MetricType{
 				Data_:      data,
-				Namespace_: core.NewNamespace([]string{"raintank", "apps", "ns1", "monitoring", jSlug, region, "state"}),
+				Namespace_: core.NewNamespace("raintank", "apps", "ns1", "monitoring", jSlug, region, "state"),
 				Timestamp_: time.Now(),
 				Version_:   mts[0].Version(),
 			})
@@ -206,7 +206,7 @@ func (n *Ns1) MonitorsMetrics(client *Client, mts []plugin.MetricType) ([]plugin
 
 				metrics = append(metrics, plugin.MetricType{
 					Data_:      m.Avg,
-					Namespace_: core.NewNamespace([]string{"raintank", "apps", "ns1", "monitoring", jSlug, jm.Region, stat}),
+					Namespace_: core.NewNamespace("raintank", "apps", "ns1", "monitoring", jSlug, jm.Region, stat),
 					Timestamp_: time.Now(),
 					Version_:   mts[0].Version(),
 				})
@@ -221,23 +221,23 @@ func (n *Ns1) GetMetricTypes(cfg plugin.ConfigType) ([]plugin.MetricType, error)
 	mts := []plugin.MetricType{}
 
 	mts = append(mts, plugin.MetricType{
-		Namespace_: core.NewNamespace([]string{"raintank", "apps", "ns1", "zones", "*", "qps"}),
+		Namespace_: core.NewNamespace("raintank", "apps", "ns1", "zones", "*", "qps"),
 		Config_:    cfg.ConfigDataNode,
 	})
 	mts = append(mts, plugin.MetricType{
-		Namespace_: core.NewNamespace([]string{"raintank", "apps", "ns1", "monitoring", "*", "*", "state"}),
+		Namespace_: core.NewNamespace("raintank", "apps", "ns1", "monitoring", "*", "*", "state"),
 		Config_:    cfg.ConfigDataNode,
 	})
 	mts = append(mts, plugin.MetricType{
-		Namespace_: core.NewNamespace([]string{"raintank", "apps", "ns1", "monitoring", "*", "*", "rtt"}),
+		Namespace_: core.NewNamespace("raintank", "apps", "ns1", "monitoring", "*", "*", "rtt"),
 		Config_:    cfg.ConfigDataNode,
 	})
 	mts = append(mts, plugin.MetricType{
-		Namespace_: core.NewNamespace([]string{"raintank", "apps", "ns1", "monitoring", "*", "*", "loss"}),
+		Namespace_: core.NewNamespace("raintank", "apps", "ns1", "monitoring", "*", "*", "loss"),
 		Config_:    cfg.ConfigDataNode,
 	})
 	mts = append(mts, plugin.MetricType{
-		Namespace_: core.NewNamespace([]string{"raintank", "apps", "ns1", "monitoring", "*", "*", "connect"}),
+		Namespace_: core.NewNamespace("raintank", "apps", "ns1", "monitoring", "*", "*", "connect"),
 		Config_:    cfg.ConfigDataNode,
 	})
 

--- a/snap/plugin/snap-collector-rt-gitstats/gitstats/gitstats.go
+++ b/snap/plugin/snap-collector-rt-gitstats/gitstats/gitstats.go
@@ -106,7 +106,7 @@ func gitStats(accessToken, owner, repo string, mts []plugin.MetricType) ([]plugi
 		if value, ok := stats[stat]; ok {
 			mt := plugin.MetricType{
 				Data_:      value,
-				Namespace_: core.NewNamespace([]string{"raintank", "apps", "gitstats", owner, repo, stat}),
+				Namespace_: core.NewNamespace("raintank", "apps", "gitstats", owner, repo, stat),
 				Timestamp_: time.Now(),
 				Version_:   m.Version(),
 			}
@@ -122,7 +122,7 @@ func (f *Gitstats) GetMetricTypes(cfg plugin.ConfigType) ([]plugin.MetricType, e
 	mts := []plugin.MetricType{}
 	for _, metricName := range metricNames {
 		mts = append(mts, plugin.MetricType{
-			Namespace_: core.NewNamespace([]string{"raintank", "apps", "gitstats", "*", "*", metricName}),
+			Namespace_: core.NewNamespace("raintank", "apps", "gitstats", "*", "*", metricName),
 			Config_:    cfg.ConfigDataNode,
 		})
 	}

--- a/snap/plugin/snap-collector-worldping-ping/ping/ping.go
+++ b/snap/plugin/snap-collector-worldping-ping/ping/ping.go
@@ -126,7 +126,7 @@ func ping(checkId, agentName, endpoint, host string, mts []plugin.MetricType) ([
 		if value, ok := stats[stat]; ok {
 			mt := plugin.MetricType{
 				Data_:      value,
-				Namespace_: core.NewNamespace([]string{"worlding", agentName, endpoint, "ping", stat}),
+				Namespace_: core.NewNamespace("worlding", agentName, endpoint, "ping", stat),
 				Timestamp_: time.Now(),
 				Version_:   m.Version(),
 			}
@@ -158,7 +158,7 @@ func ping(checkId, agentName, endpoint, host string, mts []plugin.MetricType) ([
 		}
 		mt := plugin.MetricType{
 			Data_:      message,
-			Namespace_: core.NewNamespace([]string{"worlding", "event", "monitor_state", stat}),
+			Namespace_: core.NewNamespace("worlding", "event", "monitor_state", stat),
 			Tags_:      map[string]string{"endpoint": endpoint, "probe": agentName, "monitor_type": "ping"},
 			Timestamp_: time.Now(),
 			Version_:   mts[0].Version(),
@@ -174,7 +174,7 @@ func (p *Ping) GetMetricTypes(cfg plugin.ConfigType) ([]plugin.MetricType, error
 	mts := []plugin.MetricType{}
 	for _, metricName := range metricNames {
 		mts = append(mts, plugin.MetricType{
-			Namespace_: core.NewNamespace([]string{"worldping", "*", "*", "ping", metricName}),
+			Namespace_: core.NewNamespace("worldping", "*", "*", "ping", metricName),
 		})
 	}
 	return mts, nil


### PR DESCRIPTION
Instead of passing a Bearer token, uses can use basicAuth with
the username set to "api_key".  Eg.
`curl http://api_key:<grafan.net api key>@tsdb.raintank.io/`
