### PR TITLE
Add using environment variables prefixed by 'TSDB_' for tsdb configur…

### DIFF
--- a/tsdb/main.go
+++ b/tsdb/main.go
@@ -63,9 +63,9 @@ func main() {
 	// Still parse globalconf, though, even if the config file doesn't exist
 	// because we want to be able to use environment variables.
 	conf, err := globalconf.NewWithOptions(&globalconf.Options{
-		Filename: cfile,
+		Filename:  cfile,
 		EnvPrefix: "TSDB_",
-		})
+	})
 	if err != nil {
 		panic(fmt.Sprintf("error with configuration file: %s", err))
 	}

--- a/tsdb/main.go
+++ b/tsdb/main.go
@@ -55,8 +55,8 @@ func main() {
 	flag.Parse()
 
 	// Set 'cfile' here if *confFile exists, because we should only try and
-	// parse the conf file below in that case. If we try and parse the 
-	// default conf file location when it's not there, we (unsurprisingly) 
+	// parse the conf file below in that case. If we try and parse the
+	// default conf file location when it's not there, we (unsurprisingly)
 	// get a panic. We still need to initialize a globalconf object,
 	// however, to be able to use environment variables to set configuration
 	// items.

--- a/tsdb/main.go
+++ b/tsdb/main.go
@@ -55,16 +55,17 @@ func main() {
 	flag.Parse()
 
 	// Set 'cfile' here if *confFile exists, because we should only try and
-	// parse the conf file if it exists. If we try and parse the default
-	// conf file location when it's not there, we (unsurprisingly) get a
-	// panic.
+	// parse the conf file below in that case. If we try and parse the 
+	// default conf file location when it's not there, we (unsurprisingly) 
+	// get a panic. We still need to initialize a globalconf object,
+	// however, to be able to use environment variables to set configuration
+	// items.
+
 	var cfile string
 	if _, err := os.Stat(*confFile); err == nil {
 		cfile = *confFile
 	}
 
-	// Still parse globalconf, though, even if the config file doesn't exist
-	// because we want to be able to use environment variables.
 	conf, err := globalconf.NewWithOptions(&globalconf.Options{
 		Filename:  cfile,
 		EnvPrefix: "TSDB_",

--- a/tsdb/main.go
+++ b/tsdb/main.go
@@ -54,7 +54,10 @@ var (
 func main() {
 	flag.Parse()
 
-	// Only try and parse the conf file if it exists
+	// Set 'cfile' here if *confFile exists, because we should only try and
+	// parse the conf file if it exists. If we try and parse the default
+	// conf file location when it's not there, we (unsurprisingly) get a
+	// panic.
 	var cfile string
 	if _, err := os.Stat(*confFile); err == nil {
 		cfile = *confFile

--- a/tsdb/main.go
+++ b/tsdb/main.go
@@ -55,13 +55,21 @@ func main() {
 	flag.Parse()
 
 	// Only try and parse the conf file if it exists
+	var cfile string
 	if _, err := os.Stat(*confFile); err == nil {
-		conf, err := globalconf.NewWithOptions(&globalconf.Options{Filename: *confFile})
-		if err != nil {
-			panic(fmt.Sprintf("error with configuration file: %s", err))
-		}
-		conf.ParseAll()
+		cfile = *confFile
 	}
+
+	// Still parse globalconf, though, even if the config file doesn't exist
+	// because we want to be able to use environment variables.
+	conf, err := globalconf.NewWithOptions(&globalconf.Options{
+		Filename: cfile,
+		EnvPrefix: "TSDB_",
+		})
+	if err != nil {
+		panic(fmt.Sprintf("error with configuration file: %s", err))
+	}
+	conf.ParseAll()
 
 	log.NewLogger(0, "console", fmt.Sprintf(`{"level": %d, "formatting":true}`, *logLevel))
 	// workaround for https://github.com/grafana/grafana/issues/4055


### PR DESCRIPTION
…ation

What it says on the tin - lets you set items set as argument flags or the .ini file from environment variables prefixed by **TSDB_**.

Ex.: `TSDB_ADDR=":8800" ./tsdb`

Starts tsdb up listening on port 8800 on all interfaces. A companion PR is coming momentarily for metric_tank. Both of these are for simplifying running under kubernetes.
