### PR TITLE
extend auth cache expiration if grafana.net is unreachable

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,13 @@ machine:
   environment:
     GOPATH: "/home/ubuntu/go"
     PATH: $PATH:/home/ubuntu/go/bin
+    GODIST: "go1.7.3.linux-amd64.tar.gz"
+  post:
+    - mkdir -p download
+    - test -e download/$GODIST || curl -o download/$GODIST https://storage.googleapis.com/golang/$GODIST
+    - sudo rm -rf /usr/local/go
+    - sudo tar -C /usr/local -xzf download/$GODIST
+
 dependencies:
   override:
     - scripts/deps.sh

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -21,7 +21,7 @@ var (
 	// advantage of keepalives and re-use connections instead
 	// of establishing a new tcp connection for every request.
 	client = &http.Client{
-		Timeout: time.Second,
+		Timeout: time.Second * 2,
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,0 +1,153 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/jarcoal/httpmock.v1"
+)
+
+func TestAuth(t *testing.T) {
+	mockTransport := httpmock.NewMockTransport()
+	client.Transport = mockTransport
+
+	testUser := SignedInUser{
+		Id:        3,
+		OrgName:   "awoods Test",
+		OrgSlug:   "awoodsTest",
+		OrgId:     2,
+		Name:      "testKey",
+		Role:      ROLE_EDITOR,
+		CreatedAt: time.Now(),
+		key:       "foo",
+	}
+
+	Convey("When authenticating with adminKey", t, func() {
+		user, err := Auth("key", "key")
+		So(err, ShouldBeNil)
+		So(user.Role, ShouldEqual, ROLE_ADMIN)
+		So(user.OrgId, ShouldEqual, 1)
+		So(user.OrgName, ShouldEqual, "Admin")
+		So(user.IsAdmin, ShouldEqual, true)
+		So(user.key, ShouldEqual, "key")
+	})
+	Convey("when authenticating with valid Key", t, func() {
+		responder, err := httpmock.NewJsonResponder(200, &testUser)
+		So(err, ShouldBeNil)
+		mockTransport.RegisterResponder("POST", "https://grafana.net/api/api-keys/check", responder)
+
+		user, err := Auth("key", "foo")
+		So(err, ShouldBeNil)
+		So(user.Role, ShouldEqual, testUser.Role)
+		So(user.OrgId, ShouldEqual, testUser.OrgId)
+		So(user.OrgName, ShouldEqual, testUser.OrgName)
+		So(user.OrgSlug, ShouldEqual, testUser.OrgSlug)
+		So(user.IsAdmin, ShouldEqual, testUser.IsAdmin)
+		So(user.key, ShouldEqual, testUser.key)
+		mockTransport.Reset()
+	})
+
+	Convey("When authenticating using cache", t, func() {
+		cache.Set("foo", &testUser, time.Second)
+		mockTransport.RegisterNoResponder(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected request made. %s %s", req.Method, req.URL.String())
+			return nil, nil
+		})
+		user, err := Auth("key", "foo")
+		So(err, ShouldBeNil)
+		So(user.Role, ShouldEqual, testUser.Role)
+		So(user.OrgId, ShouldEqual, testUser.OrgId)
+		So(user.OrgName, ShouldEqual, testUser.OrgName)
+		So(user.OrgSlug, ShouldEqual, testUser.OrgSlug)
+		So(user.IsAdmin, ShouldEqual, testUser.IsAdmin)
+		So(user.key, ShouldEqual, testUser.key)
+		mockTransport.Reset()
+	})
+
+	Convey("When authenticating using expired cache", t, func() {
+		cache.Set("bar", &testUser, 0)
+		responder, err := httpmock.NewJsonResponder(200, &testUser)
+		So(err, ShouldBeNil)
+		mockTransport.RegisterResponder("POST", "https://grafana.net/api/api-keys/check", responder)
+
+		// make sure cached item is expired.
+		cuser, valid := cache.Get("bar")
+		So(cuser, ShouldNotBeNil)
+		So(valid, ShouldBeFalse)
+
+		user, err := Auth("key", "bar")
+		So(err, ShouldBeNil)
+		So(user.Role, ShouldEqual, testUser.Role)
+		So(user.OrgId, ShouldEqual, testUser.OrgId)
+		So(user.OrgName, ShouldEqual, testUser.OrgName)
+		So(user.OrgSlug, ShouldEqual, testUser.OrgSlug)
+		So(user.IsAdmin, ShouldEqual, testUser.IsAdmin)
+		So(user.key, ShouldEqual, "bar")
+
+		// make sure cache is now updated.
+		cuser, valid = cache.Get("bar")
+		So(cuser, ShouldNotBeNil)
+		So(valid, ShouldBeTrue)
+
+		mockTransport.Reset()
+	})
+
+	Convey("When authenticating using expired cache and bad g.net response", t, func() {
+		cache.Set("baz", &testUser, 0)
+		responder, err := httpmock.NewJsonResponder(503, nil)
+		So(err, ShouldBeNil)
+		mockTransport.RegisterResponder("POST", "https://grafana.net/api/api-keys/check", responder)
+
+		// make sure cached item is expired.
+		cuser, valid := cache.Get("baz")
+		So(cuser, ShouldNotBeNil)
+		So(valid, ShouldBeFalse)
+
+		user, err := Auth("key", "baz")
+		So(err, ShouldBeNil)
+		So(user.Role, ShouldEqual, testUser.Role)
+		So(user.OrgId, ShouldEqual, testUser.OrgId)
+		So(user.OrgName, ShouldEqual, testUser.OrgName)
+		So(user.OrgSlug, ShouldEqual, testUser.OrgSlug)
+		So(user.IsAdmin, ShouldEqual, testUser.IsAdmin)
+		So(user.key, ShouldEqual, testUser.key)
+
+		// make sure cache is now updated.
+		cuser, valid = cache.Get("baz")
+		So(cuser, ShouldNotBeNil)
+		So(valid, ShouldBeTrue)
+
+		mockTransport.Reset()
+	})
+	Convey("When authenticating using expired cache and no g.net response", t, func() {
+		cache.Set("baz", &testUser, 0)
+		mockTransport.RegisterResponder("POST", "https://grafana.net/api/api-keys/check", func(req *http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("failed")
+		})
+
+		// make sure cached item is expired.
+		cuser, valid := cache.Get("baz")
+		So(cuser, ShouldNotBeNil)
+		So(valid, ShouldBeFalse)
+
+		user, err := Auth("key", "baz")
+		So(err, ShouldBeNil)
+		So(user.Role, ShouldEqual, testUser.Role)
+		So(user.OrgId, ShouldEqual, testUser.OrgId)
+		So(user.OrgName, ShouldEqual, testUser.OrgName)
+		So(user.OrgSlug, ShouldEqual, testUser.OrgSlug)
+		So(user.IsAdmin, ShouldEqual, testUser.IsAdmin)
+		So(user.key, ShouldEqual, testUser.key)
+
+		// make sure cache is now updated.
+		cuser, valid = cache.Get("baz")
+		So(cuser, ShouldNotBeNil)
+		So(valid, ShouldBeTrue)
+
+		mockTransport.Reset()
+	})
+
+}


### PR DESCRIPTION
This patch attempts to extend the auth cache expiration if grafana.net is unreachable or returning 5XX status codes, so that users are still able to authenticate.

I'm not sure how to go about running/testing this code...