### PR TITLE
make auth-endpoint configurable

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -95,8 +95,8 @@ func (a *AuthCache) Clear() {
 
 func init() {
 	flag.StringVar(&authEndpoint, "auth-endpoint", authEndpoint, "Endpoint to authenticate users on")
-	flag.DurationVar(&validTTL, "valid-ttl", time.Minute*5, "how long valid responses should be cached")
-	flag.DurationVar(&invalidTTL, "invalid-ttl", time.Second*30, "how long invalid responses should be cached")
+	flag.DurationVar(&validTTL, "valid-ttl", validTTL, "how long valid responses should be cached")
+	flag.DurationVar(&invalidTTL, "invalid-ttl", invalidTTL, "how long invalid responses should be cached")
 	flag.Var(&validOrgIds, "valid-org-id", "org ids that may be passed separated by ,")
 	cache = &AuthCache{items: make(map[string]CacheItem)}
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -17,7 +17,7 @@ import (
 var (
 	validTTL     = time.Minute * 5
 	invalidTTL   = time.Second * 30
-	authEndpoint string
+	authEndpoint = "https://grafana.net"
 	cache        *AuthCache
 
 	// global HTTP client.  By sharing the client we can take
@@ -68,7 +68,7 @@ func (a *AuthCache) Set(key string, u *SignedInUser, ttl time.Duration) {
 }
 
 func init() {
-	flag.StringVar(&authEndpoint, "auth-endpoint", "https://grafana.net", "Endpoint to authenticate users on")
+	flag.StringVar(&authEndpoint, "auth-endpoint", authEndpoint, "Endpoint to authenticate users on")
 	cache = &AuthCache{items: make(map[string]CacheItem)}
 }
 

--- a/pkg/auth/roles.go
+++ b/pkg/auth/roles.go
@@ -9,6 +9,7 @@ import (
 var (
 	ErrInvalidRoleType = errors.New("Invalid role type")
 	ErrInvalidApiKey   = errors.New("Invalid API Key")
+	ErrInvalidOrgId    = errors.New("Invalid Org Id")
 )
 
 type RoleType string

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -21,6 +21,12 @@ go get github.com/intelsdi-x/snap-plugin-lib-go/...
 cd /home/ubuntu/go/src/github.com/intelsdi-x/snap-plugin-lib-go
 glide up
 
+mkdir -p /home/ubuntu/go/src/github.com/google
+cd /home/ubuntu/go/src/github.com/google
+git clone https://github.com/google/go-github
+cd go-github
+git checkout 2ec691a35b10b8c1471955a96d0f182a572e1cad
+
 cd /home/ubuntu/go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
 go get -t ./...
 


### PR DESCRIPTION
i didn't actually test if the `flag.StringVar` sets the value correctly, but i can see the option here:
```
mst@mst-nb1:~/documents/code/go/src/github.com/raintank/tsdb-gw/build$ ./tsdb-gw -h
Usage of ./tsdb-gw:
  -addr string
    	http service address (default "localhost:80")
  -admin-key string
    	Admin Secret Key (default "not_very_secret_key")
  -auth-endpoint string
    	Endpoint to authenticate users on (default "https://grafana.net")
  -cert-file string
    	SSL certificate file
  -config string
    	configuration file path (default "/etc/raintank/tsdb.ini")
  -elasticsearch-url string
    	elasticsearch server address (default "http://localhost:9200")
  -es-index string
    	elasticsearch index name (default "events")
  -event-topic string
    	NSQ topic for events (default "events")
  -graphite-url string
    	graphite-api address (default "http://localhost:8080")
  -kafka-comp string
    	compression: none|gzip|snappy (default "none")
  -kafka-tcp-addr string
    	kafka tcp address for metrics (default "localhost:9092")
  -key-file string
    	SSL key file
  -log-level int
    	log level. 0=TRACE|1=DEBUG|2=INFO|3=WARN|4=ERROR|5=CRITICAL|6=FATAL (default 2)
  -metric-topic string
    	topic for metrics (default "mdm")
  -metrictank-url string
    	metrictank address (default "http://localhost:6060")
  -partition-scheme string
    	method used for paritioning metrics. (byOrg|bySeries) (default "bySeries")
  -publish-events
    	enable event publishing
  -publish-metrics
    	enable metric publishing
  -ssl
    	use https
  -stats-enabled
    	enable statsd metrics
  -statsd-addr string
    	statsd address (default "localhost:8125")
  -statsd-type string
    	statsd type: standard or datadog (default "standard")
  -version
    	print version string
  -worldping-url string
    	worldping-api address (default "http://localhost/")
```