### PR TITLE
refactor task-agent scheduler

### DIFF
--- a/task-agent-ng/main.go
+++ b/task-agent-ng/main.go
@@ -87,7 +87,7 @@ func main() {
 		log.Fatal("name must be set.")
 	}
 
-	InitTaskCache(tsdbgwAddr, tsdbgwAdminAPIKey)
+	InitTaskRunner(*tsdbgwAddr, *tsdbgwAdminAPIKey)
 
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)

--- a/task-agent-ng/publisher/publisher.go
+++ b/task-agent-ng/publisher/publisher.go
@@ -29,6 +29,7 @@ var (
 
 var (
 	tsdbgwSendSuccessCount      = stats.NewCounter32("tsdbgw.send.success")
+	tsdbgwSendMetrics           = stats.NewCounter32("tsdbgw.send.metrics")
 	tsdbgwSendFailureCount      = stats.NewCounter32("tsdbgw.send.failure")
 	tsdbgwSendSuccessDurationNS = stats.NewGauge64("tsdbgw.send.success.duration_ns")
 	tsdbgwSendFailureDurationNS = stats.NewGauge64("tsdbgw.send.failure.duration_ns")
@@ -118,6 +119,7 @@ func (t *Tsdb) run() {
 		if len(metrics[shard]) == 0 {
 			return
 		}
+		tsdbgwSendMetrics.Add(len(metrics[shard]))
 		mda := schema.MetricDataArray(metrics[shard])
 		data, err := msg.CreateMsg(mda, 0, msg.FormatMetricDataArrayMsgp)
 		if err != nil {

--- a/task-agent-ng/task_cache.go
+++ b/task-agent-ng/task_cache.go
@@ -2,175 +2,16 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
-	"net/url"
-	"sync"
-	"time"
-
-	"github.com/grafana/metrictank/stats"
-	"github.com/raintank/raintank-apps/task-agent-ng/collector-ns1/ns1"
-	"github.com/raintank/raintank-apps/task-agent-ng/collector-voxter/voxter"
-	"github.com/raintank/raintank-apps/task-agent-ng/publisher"
 
 	"github.com/raintank/raintank-apps/task-agent-ng/taskrunner"
 	"github.com/raintank/raintank-apps/task-server/model"
 	log "github.com/sirupsen/logrus"
 )
 
-var (
-	taskAddedCount   = stats.NewCounter32("tasks.added")
-	taskUpdatedCount = stats.NewCounter32("tasks.updated")
-	taskRemovedCount = stats.NewCounter32("tasks.removed")
-	taskInvalidCount = stats.NewCounter32("tasks.invalid")
-)
+var taskRunner *taskrunner.TaskRunner
 
-type Plugin interface {
-	CollectMetrics()
-}
-
-type TaskCache struct {
-	sync.RWMutex
-	tsdbgwURL    *url.URL
-	tsdbgwAPIKey *string
-	Tasks        map[int64]*model.TaskDTO
-	initialized  bool
-	TaskRunner   taskrunner.TaskRunner
-	Publisher    *publisher.Tsdb
-}
-
-// AddTask given a TaskDTO this will create a new job
-func (t *TaskCache) AddTask(task *model.TaskDTO) error {
-	t.Lock()
-	defer t.Unlock()
-	return t.addTask(task)
-}
-
-func (t *TaskCache) addTask(task *model.TaskDTO) error {
-	t.Tasks[task.Id] = task
-	if !t.initialized {
-		return nil
-	}
-	taskName := fmt.Sprintf("raintank-apps:%d", task.Id)
-	// check if job already exists
-
-	aJob, ok := t.TaskRunner.Exists(int(task.Id))
-	if !ok {
-		log.Debugf("New task received %s", taskName)
-		t.AddToTaskRunner(task)
-	} else {
-		log.Debugf("task %s already in the cache.", taskName)
-		// check age of creation timestamp vs the task updated Timestamp
-		// if the running job is has an older timestamp, remove it and create a new job
-		if task.Updated.After(time.Unix(aJob.CreationTimestamp, 0)) {
-			log.Infof("%s is stale and needs to be updated", taskName)
-			// need to update task
-			// remove it first
-			t.TaskRunner.Remove(aJob)
-			// then add it
-			t.AddToTaskRunner(task)
-		}
-	}
-
-	return nil
-}
-
-// AddToTaskRunner decodes the type of plugin to use from the config and creates a new cron task
-func (t *TaskCache) AddToTaskRunner(task *model.TaskDTO) {
-	var plugin Plugin
-	var err error
-	log.Infof("adding task of type %s", task.TaskType)
-	switch task.TaskType {
-	case "/raintank/apps/ns1":
-		plugin, err = ns1.New(task, t.Publisher)
-		if err != nil {
-			log.Errorf("failed to add ns1 task %d. %s", task.Id, err)
-			taskInvalidCount.Inc()
-			return
-		}
-	case "/raintank/apps/voxter":
-		plugin, err = voxter.New(task, t.Publisher)
-		if err != nil {
-			log.Errorf("failed to add ns1 task. %s", err)
-			taskInvalidCount.Inc()
-			return
-		}
-		return
-	default:
-		log.Info("Unknown Plugin Needed!")
-		return
-	}
-	taskAddedCount.Inc()
-	sched := fmt.Sprintf("@every %ds", task.Interval)
-	id1 := t.TaskRunner.Add(int(task.Id), sched, plugin.CollectMetrics)
-	log.Infof("task %d assigned cron id: %v", task.Id, id1)
-}
-
-// UpdateTasks Iterates over the tasks and removes stale entries
-func (t *TaskCache) UpdateTasks(tasks []*model.TaskDTO) {
-	seenTaskIds := make(map[int64]struct{})
-	t.Lock()
-	for _, task := range tasks {
-		seenTaskIds[task.Id] = struct{}{}
-		err := t.addTask(task)
-		if err != nil {
-			log.Error(err.Error())
-		}
-	}
-	tasksToDel := make([]*model.TaskDTO, 0)
-	for id, task := range t.Tasks {
-		if _, ok := seenTaskIds[id]; !ok {
-			tasksToDel = append(tasksToDel, task)
-		}
-	}
-	t.Unlock()
-	if len(tasksToDel) > 0 {
-		for _, task := range tasksToDel {
-			if err := t.RemoveTask(task); err != nil {
-				log.Errorf("Failed to remove task %d", task.Id)
-			}
-		}
-	}
-}
-
-func (t *TaskCache) RemoveTask(task *model.TaskDTO) error {
-	t.Lock()
-	defer t.Unlock()
-	log.Debugf("removing task %d", task.Id)
-	if err := t.removeActiveTask(task); err != nil {
-		return err
-	}
-	delete(t.Tasks, task.Id)
-	return nil
-}
-
-func (t *TaskCache) removeActiveTask(task *model.TaskDTO) error {
-	aJob, ok := t.TaskRunner.Exists(int(task.Id))
-	if !ok {
-		log.Debugf("removeActiveTask: task does not exist %d", task.Id)
-		return fmt.Errorf("task does not exist")
-	}
-	t.TaskRunner.Remove(aJob)
-	taskRemovedCount.Inc()
-	return nil
-}
-
-var GlobalTaskCache *TaskCache
-
-func InitTaskCache(tsdbgwAddr *string, tsdbgwApiKey *string) {
-	log.Infof("TSDB-GW URL is %s", *tsdbgwAddr)
-	tsdbgwURL, err := url.Parse(*tsdbgwAddr)
-	if err != nil {
-		log.Fatalf("Invalid TSDB url. %s", err)
-	}
-	GlobalTaskCache = &TaskCache{
-		tsdbgwURL: tsdbgwURL,
-		Tasks:     make(map[int64]*model.TaskDTO),
-	}
-
-	GlobalTaskCache.Publisher = publisher.NewTsdb(tsdbgwURL, *tsdbgwApiKey, 1)
-	GlobalTaskCache.TaskRunner = taskrunner.TaskRunner{}
-	GlobalTaskCache.TaskRunner.Init()
-	GlobalTaskCache.initialized = true
+func InitTaskRunner(tsdbgwAddr, tsdbgwAdminAPIKey string) {
+	taskRunner = taskrunner.NewTaskRunner(tsdbgwAddr, tsdbgwAdminAPIKey)
 }
 
 func HandleTaskList() interface{} {
@@ -182,7 +23,7 @@ func HandleTaskList() interface{} {
 			return
 		}
 		log.Debugf("TaskList. %s", data)
-		GlobalTaskCache.UpdateTasks(tasks)
+		taskRunner.UpdateTasks(tasks)
 	}
 }
 
@@ -195,7 +36,7 @@ func HandleTaskUpdate() interface{} {
 			return
 		}
 		log.Debugf("TaskUpdate. %s", data)
-		if err := GlobalTaskCache.AddTask(&task); err != nil {
+		if err := taskRunner.AddTask(&task); err != nil {
 			log.Errorf("failed to add task to cache. %s", err)
 		}
 	}
@@ -210,7 +51,7 @@ func HandleTaskAdd() interface{} {
 			return
 		}
 		log.Debug("Adding Task. %s", data)
-		if err := GlobalTaskCache.AddTask(&task); err != nil {
+		if err := taskRunner.AddTask(&task); err != nil {
 			log.Errorf("failed to add task to cache. %s", err)
 		}
 	}
@@ -225,7 +66,7 @@ func HandleTaskRemove() interface{} {
 			return
 		}
 		log.Debugf("Removing Task. %s", data)
-		if err := GlobalTaskCache.RemoveTask(&task); err != nil {
+		if err := taskRunner.RemoveTask(&task); err != nil {
 			log.Errorf("failed to remove task from cache. %s", err)
 		}
 	}

--- a/task-agent-ng/taskrunner/ticker.go
+++ b/task-agent-ng/taskrunner/ticker.go
@@ -1,0 +1,94 @@
+package taskrunner
+
+import (
+	"sync"
+	"time"
+)
+
+type Ticker struct {
+	sync.Mutex
+	stopped  bool
+	interval int64
+	offset   int64
+	timer    *time.Timer
+	C        chan time.Time
+	shutdown chan struct{}
+}
+
+func NewTicker(interval int64, offset int64) *Ticker {
+	t := &Ticker{
+		stopped:  true,
+		interval: interval,
+		offset:   offset,
+		C:        make(chan time.Time, 1),
+		shutdown: make(chan struct{}),
+	}
+	return t
+}
+
+func (t *Ticker) Ticks() {
+	// read from our timer chan until we get a shutdown notfication.
+	for {
+		select {
+		case <-t.shutdown:
+			close(t.C)
+			return
+		case ts := <-t.timer.C:
+			t.C <- ts
+			t.next()
+		}
+	}
+}
+
+func (t *Ticker) Update(interval int64, offset int64) {
+	t.Lock()
+	t.interval = interval
+	t.offset = offset
+	t.Unlock()
+}
+
+func (t *Ticker) next() {
+	t.Lock()
+	if t.stopped {
+		// the ticker has been stopped.  No new write will be made to t.C until
+		// t.Start() is called again.
+		t.Unlock()
+		return
+	}
+	// calculate the number of seconds until our next tick.
+	now := time.Now().Unix()
+	nextTick := ((t.interval + t.offset) - (now % t.interval)) % t.interval
+	if nextTick == 0 {
+		nextTick = t.interval
+	}
+
+	// set the timer to fire in nextTicks seconds.
+	if t.timer == nil {
+		t.timer = time.NewTimer(time.Second * time.Duration(nextTick))
+		go t.Ticks()
+	} else {
+		t.timer.Reset(time.Second * time.Duration(nextTick))
+	}
+	t.Unlock()
+}
+
+// start sending ticks on t.C
+func (t *Ticker) Start() {
+	t.Lock()
+	t.stopped = false
+	t.Unlock()
+	t.next()
+}
+
+// stop sending ticks on t.C
+func (t *Ticker) Stop() {
+	t.Lock()
+	t.stopped = true
+	t.Unlock()
+}
+
+// kill the ticker.  This will close t.C
+func (t *Ticker) Delete() {
+	t.Stop()
+	close(t.shutdown)
+}


### PR DESCRIPTION
The cron task scheduler being used was not suitable.  The majority
of tasks run every 5mins and are scraping stats from the same 3rd
party api.  With the cron approach, all tasks were running at the same
time, then sitting idle for 5mins. This puts unnecessary strain on
the remote endpoint and could lead to requests failing or being
rate limited.
So instead we use a more controlled approach with each job runnning
in its own goroutine. Jobs are distributed throughout the interval.
This approach will easily scale to 100k++ jobs per agent.